### PR TITLE
Add Remote Technology Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ https://www.flexjobs.com (paid subscription required, $14.99/monthly unless they
 https://remoteok.io  
 https://codepen.io/jobs  
 https://www.usajobs.gov (search on keywords 'location negotiable')
+https://standardresume.co/remote-jobs (filter for remote jobs hiring from your location)
 
 Newsletters:  
 [Remotive Tips](https://remoteworking.curated.co)  


### PR DESCRIPTION
It has the ability to hide jobs that aren't hiring from where you live. This makes searching much easier as many remote jobs still have applicant location restrictions.